### PR TITLE
Use environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Get It Done
+
+This Flask application expects certain configuration values to be supplied via environment variables before it is run.
+
+## Required environment variables
+
+- `DATABASE_URL` – SQLAlchemy connection string for the application's database, e.g. `mysql+pymysql://user:password@localhost:8889/get-it-done`
+- `SECRET_KEY` – Secret key used by Flask to sign session cookies.
+
+Set these in your environment or in a `.env` file before starting the application.

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
+import os
 from flask import Flask, request, redirect, render_template, session, flash
 from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
 app.config['DEBUG'] = True
-app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://get-it-done:getitdone@localhost:8889/get-it-done'
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
 app.config['SQLALCHEMY_ECHO'] = True
 db = SQLAlchemy(app)
-app.secret_key = "doodle"
+app.secret_key = os.environ.get('SECRET_KEY')
 
 class Task(db.Model): 
 


### PR DESCRIPTION
## Summary
- Replace hard-coded database credentials and secret key with `os.environ` lookups.
- Document required `DATABASE_URL` and `SECRET_KEY` variables.

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bdf28b6288330ab1ef90c35ebb498